### PR TITLE
acond: Modify cargo config to use default rust target and turn on more optimization

### DIFF
--- a/acond/.cargo/config.toml
+++ b/acond/.cargo/config.toml
@@ -1,4 +1,0 @@
-# Copyright (C) 2023 Intel Corporation
-
-[build]
-target = "x86_64-unknown-linux-musl"

--- a/acond/.gitignore
+++ b/acond/.gitignore
@@ -1,0 +1,3 @@
+# Copyright (C) 2023 Intel Corporation
+
+target/

--- a/acond/Cargo.toml
+++ b/acond/Cargo.toml
@@ -40,5 +40,8 @@ full = ["interactive"]
 interactive = []
 
 [profile.release]
+opt-level = "s"
+strip = true
 lto = true
-panic = 'abort'
+panic = "abort"
+codegen-units = 1


### PR DESCRIPTION
This PR removes `.cargo/config.toml` to let cargo use the default target. This aligns with #9 to build `acond` in [rust container](https://hub.docker.com/_/rust/) with default rust target.

Some more optimization options are turned on in the 'release' profile, including

- `opt-level = "s"` to optimize for size.
- `strip = true` to strip symbol info from the final executable.
- `codegen-units = 1` to maximize optimization.

A `.gitignore` is also added to ignore the build output (`target/`) directory.