### PR TITLE
scripts: Add scripting support for start_rust_buildenv

### DIFF
--- a/scripts/acon-build.env
+++ b/scripts/acon-build.env
@@ -791,48 +791,74 @@ start_rust_buildenv() {
     local readonly _wrn="${_FC3}${_FB}WARNING${_FP}\\t"
     local readonly _inf="${_FB}INFO${_FP}\\t"
 
-    case x$1 in
-        x)  set -- $(git rev-parse --show-toplevel)
-            test -z "$1" && {
-                echo -e ${_err}Failed to deduce ACON root from current directory >&2
-                return 2
-            };;
-        x-h|x--help)
-            echo 'usage: start_rust_buildenv [ACON_ROOT]
+    while test $# -gt 0; do
+        case x$1 in
+            x--)
+                shift
+                break;;
+            x-h|x--help)
+                echo 'usage: start_rust_buildenv [-- COMMAND...]
 
-ACON_ROOT is the root directory of the ACON project and if omitted, it is
-deduced from the current directory using git';
-            return 1;;
-        x-*)
-            echo -e "${_err}Unknown option $1"
-            return 1;;
-    esac
+start_rust_buildenv starts a rust container (https://hub.docker.com/_/rust) and
+sets it up for building ACON Deamon. The optional COMMAND... specifies the
+command (and its command line arguments) to be executed after the container
+starts.
+' >&2
+                _format_help__ "Environment Variables:" \
+                    ACON    "Set to project root to avoid deducing using git" \
+                    RUSTAG  "Tag of rust container image, default 'alpine'" \
+                    U       "Set to UID:GID, or '.' to use current user's IDs" \
+                    "" >&2
+                return 1;;
+            x*)
+                echo -e ${_err}Unknown arguments: "$@" >&2
+                return 2;;
+        esac
+    done
 
-    test -d "$1" -a -d "$1/scripts" || {
-        echo -e ${_err}$1: Not exist or ACON project root >&2
+    if test $# -gt 0; then
+        local RM="--rm --init"
+    else
+        set -- sh -i
+    fi
+
+    test -n "$ACON" || local ACON=$(git rev-parse --show-toplevel)
+    test -n "$ACON" || {
+        echo -e ${_err}Failed to deduce ACON root from current directory >&2
         return 3
     }
-    set -- $(readlink -f $1)
+
+    test -e "$ACON/scripts/${BASH_SOURCE[0]##*/}" || {
+        echo -e ${_err}$ACON: Not an ACON source tree >&2
+        return 4
+    }
+
+    ACON=$(readlink -f $ACON)
+    test -d "$ACON" -a -z "${ACON##/*}" || {
+        echo -e ${_err}$ACON isn\'t a valid directory path >&2
+        return 4
+    }
 
     local readonly rustimg=rust:${RUSTAG:-alpine}
-    printf "${_FB}%s${_FP}\\t%s\\n" 'ACON Repo' "$1" 'Rust OCI Image' $rustimg |
+    test -z "$RM" &&
+    printf "${_FB}%s${_FP}\\t%s\\n" 'ACON Repo' "$ACON" 'Rust OCI Image' $rustimg |
     column -t -s$'\t' >&2
 
-    local readonly chash=$(sha1sum <<< "$1 $rustimg $HTTPS_PROXY\\$https_proxy")
+    local readonly chash=$(sha1sum <<< "$ACON\\$rustimg\\$HTTPS_PROXY\\$https_proxy")
     local readonly cname=acon-rust.$(id -un).${chash:0:12}
     case x$(docker ps -af name=$cname --format "{{.State}}") in
         xcreated|xexited)
             echo -e ${_inf}$cname: Starting existing container... >&2
             docker start -ia $cname;;
         xrunning)
-            echo -e ${_wrn}$cname: Executing new shell in running container... >&2
-            docker exec -it $cname sh -i;;
+            test -z "$RM" && echo -e ${_wrn}$cname: Executing new shell in running container... >&2
+            docker exec -it $cname "$@";;
         xpaused)
             echo -e ${_wrn}$cname: Resuming paused container in its original terminal... >&2
             docker unpause $cname;;
         x)
             echo -e ${_inf}$cname: Creating new container... >&2
-            docker run -it --name $cname --label ACON=$1 -v $1:/acon -w /acon/acond \
+            docker run $RM -it --name $cname --label ACON=$ACON -v $ACON:/acon -w /acon/acond \
                 -e HTTPS_PROXY -e https_proxy ${U:+-e U=${U/#.*/$(id -u):$(id -g)}} $rustimg sh -c "
                 . /etc/os-release || {
                     echo -e \"${_err}/etc/os-release: Not found\" >&2
@@ -841,7 +867,7 @@ deduced from the current directory using git';
 
                 alpine_init() {
                     if ! test -f PACKAGES-INFO; then
-                        echo -e \"${_inf}Downloading dependencies...\" >&2 &&
+                        echo -e \"${_inf}Downloading dependencies into \$PWD ...\" >&2 &&
                         apk fix && apk fetch -w &&
                         apk fetch -R musl-dev openssl-dev protobuf-dev openssl-libs-static &&
                         printf '%s=%s\\n' OS \$ID VERSION \$VERSION_ID TIMESTAMP \$(date +%s) > PACKAGES-INFO
@@ -857,15 +883,15 @@ deduced from the current directory using git';
                         echo u\${U%:*}:x:\$U:xuser:/:/sbin/nologin >> /etc/passwd
 
                         apk --cache-dir /var/cache/apk add daemontools-encore &&
-                        exec setuidgid u\${U%:*} sh -i
+                        exec setuidgid u\${U%:*} \"\$@\"
                     else
-                        exec sh -i
+                        exec \"\$@\"
                     fi
                 }
 
                 readonly deps_dir=/acon/scripts/deps/rust-\$RUST_VERSION/\$ID &&
                 mkdir -p \$deps_dir && cd \$deps_dir &&
-                \${ID}_init \"\$@\"";;
+                \${ID}_init \"\$@\"" -- "$@";;
         x*)
             echo -e ${_err}$cname: Unexpected container state >&2
             return 4;;


### PR DESCRIPTION
`start_rust_buildenv` currently supports interactive invocation only. This commit adds the following features.

- Allow user to specify command to execute, by appending `--` followed by the actual command.
- Container started by custom command will be created with `--rm --init` appended to `docker run` - i.e., the container will be removed once exited.
- Custom commands are supported by existing containers too. This is done by passing through the command line to `docker exec`.