### PR TITLE
aconcli: Improve help messages

### DIFF
--- a/aconcli/cmd/alias-substitute.go
+++ b/aconcli/cmd/alias-substitute.go
@@ -15,11 +15,20 @@ import (
 var substituteAll bool
 
 var aliasCmd = &cobra.Command{
-	Use:   "alias-substitute <manifest-file>",
-	Short: "Substitute file system layer digests with aliases",
+	Use:     "alias-substitute manifest",
+	Short:   "Substitute file system layer digests with aliases",
+	GroupID: "image",
 	Long: `
-Substitute the digests of file system layers from specified
-manifest file with the alias names recorded in the ACON repository`,
+Substitute digests of file system layers in the specified ACON image manifest
+with aliases defined in ACON images/manifests stored in the same ACON image
+repo where the specified manifest resides.
+
+The ACON image repo path is implied by the manifest file path.
+
+By default, only signed images/manifests are searched for alias definitions
+unless '-a' is specified, in which case both signed and unsigned manifests are
+searched.
+`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return aliasSubstitute(args)
@@ -54,5 +63,5 @@ func aliasSubstitute(args []string) error {
 func init() {
 	rootCmd.AddCommand(aliasCmd)
 	aliasCmd.Flags().BoolVarP(&substituteAll, "all", "a", false,
-		"consider all manifest files, even though there is no associated signature file")
+		"search both signed and unsigned manifests for alias definitions")
 }

--- a/aconcli/cmd/export.go
+++ b/aconcli/cmd/export.go
@@ -15,14 +15,25 @@ import (
 var ignoreSig bool
 
 var releaseCmd = &cobra.Command{
-	Use:   "export <manifest-file>",
-	Short: "Export the ACON image into a tarball file",
+	Use:     "export manifest",
+	Short:   "Export ACON images into tarballs",
+	GroupID: "image",
 	Long: `
-Export the ACON image corresponding to the specified manifest file into
-a tarball. The image includes a manifest file, a signature file, a
-certificate file to verify the signature, and the file system layers
-of the image. The images on which the specified image depends will not
-be exported`,
+Export an ACON image (specified as the path to its manifest) into a tarball.
+
+An ACON image is comprised of a manifest file, a signature file (containing
+the digital signature of the manifest), a certificate file (for verifying the
+signature), and the file system layers referenced by the manifest. 'aconcli
+export' packages all those files in a single tarball, which can then be
+imported into a different ACON image repo by 'aconcli import'.
+
+NOTE1: Only those file system layers referenced by digests will be exported,
+while others referenced by aliases will NOT be exported.
+
+NOTE2: ACON images that the specified manifest depends on (i.e., images
+defining aliases that have been referenced by the specified manifest) will NOT
+be exported.
+`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return exportBundles(args)
@@ -53,6 +64,6 @@ func init() {
 	releaseCmd.Flags().BoolVarP(&ignoreSig, "ignoresig", "", false,
 		"ignoring missing signature file while exporting image")
 	releaseCmd.Flags().StringVarP(&exportName, "output", "o", "",
-		"name of the output tarball file to hold the exported image")
+		"output tarball file name")
 	releaseCmd.MarkFlagRequired("output")
 }

--- a/aconcli/cmd/generate.go
+++ b/aconcli/cmd/generate.go
@@ -18,8 +18,9 @@ import (
 )
 
 var generateCmd = &cobra.Command{
-	Use:   "generate <docker-image>",
-	Short: "Generate a manifest file and commit file system layers to ACON repository",
+	Use:     "generate <docker-image>",
+	Short:   "Generate a manifest file and commit file system layers to ACON repository",
+	GroupID: "image",
 	Long: `
 Generate a manifest file in JSON format and commit to ACON repository
 the file system layers from specified Docker image. The output manifest

--- a/aconcli/cmd/hash.go
+++ b/aconcli/cmd/hash.go
@@ -14,11 +14,16 @@ import (
 )
 
 var hashCmd = &cobra.Command{
-	Use:   "hash <certificate-file>  <manifest-file>...",
-	Short: "Generate the hash digest for the manifest file",
+	Use:   "hash certificate [manifest]...",
+	Short: "Compute SignerID and ImageIDs",
 	Long: `
-Generate the hash digest for the manifest file using the hash
-algorithm extracted from the specified certificate file`,
+Compute the digests of the specified certificate and manifest files using the
+hash algorithm deduced from the certificate file.
+
+Outputs from 'aconcli hash' are the SignerID of the certificate file and the
+ImageIDs of the manifest files as if signed by that certificate.
+`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doHash(args)
 	},
@@ -33,7 +38,7 @@ func doHash(args []string) error {
 		fmt.Fprintf(os.Stderr, "Failed to get hash algorithm and digest for %s: %v\n", certFile, err)
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "%s: %v\n", certFile, hex.EncodeToString(certDigest))
+	fmt.Fprintf(os.Stdout, "%s/%v\t%s\n", hashAlgo, hex.EncodeToString(certDigest), certFile)
 
 	for _, file := range files {
 		content, err := os.ReadFile(filepath.Clean(file))
@@ -53,7 +58,8 @@ func doHash(args []string) error {
 			fmt.Fprintf(os.Stderr, "Failed to get digest for %s: %v\n", file, err)
 			continue
 		}
-		fmt.Fprintf(os.Stdout, "%s: %v\n", file, hex.EncodeToString(manifestDigest))
+		fmt.Fprintf(os.Stdout, "%s/%v/%v\t%s\n", hashAlgo,
+			hex.EncodeToString(certDigest), hex.EncodeToString(manifestDigest), file)
 	}
 	return nil
 }

--- a/aconcli/cmd/import.go
+++ b/aconcli/cmd/import.go
@@ -12,12 +12,13 @@ import (
 )
 
 var importCmd = &cobra.Command{
-	Use:   "import <tarball-file>...",
-	Short: "Import ACON images into the ACON repository",
+	Use:     "import tarball...",
+	Short:   "Import ACON images from tarballs",
+	GroupID: "image",
 	Long: `
-Import existing ACON images represented by the specified tarballs into
-the ACON repositoy. Imported images will be referenced during alias
-substitution process performed by 'aconcli alias-substitute' subcommand`,
+Import ACON images from tarballs (created by 'aconcli export') into the current
+ACON image repo, whose path is determined by the current working directory.
+`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return importManifest(args)

--- a/aconcli/cmd/init.go
+++ b/aconcli/cmd/init.go
@@ -17,12 +17,15 @@ import (
 var repodir string
 
 var initCmd = &cobra.Command{
-	Use:   "init [<directory-path>]",
-	Short: "Create an empty ACON repository",
+	Use:     "init [<directory-path>]",
+	Short:   "Initialize ACON image repo",
+	GroupID: "image",
 	Long: `
-Create an empty ACON repository named '.acon'. The repository  will be
-created within the specified directory. If the directory path is omitted,
-it will be created under current directory`,
+Initialize an empty ACON image repo in the current working directory.
+
+An ACON image repo is a directory containing a subdirectory named '.acon',
+under which ACON image files reside.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return createRepo(args)
 	},

--- a/aconcli/cmd/invoke.go
+++ b/aconcli/cmd/invoke.go
@@ -18,13 +18,21 @@ var (
 )
 
 var invokeCmd = &cobra.Command{
-	Use:   "invoke <custom-command>",
-	Short: "Invoke custom command on an ACON container",
+	Use:     "invoke custom_command [args]...",
+	Short:   "Invoke custom command in an ACON container",
+	GroupID: "runtime",
 	Long: `
-Invoke custom command on an ACON container within an ACON virtual machine.
-The ACON virtual machine  needs to be specified by the '-c' flag while ACON
-container needs to be specified by the '-e' flag. Both information can be
-obtained by using the 'aconcli status' subcommand`,
+Invoke a custom command in an existing ACON container within an ACON TD/VM.
+
+The ACON TD/VM must be specified by the '-c' flag while the ACON container must
+be specified by the '-e' flag. Use 'aconcli status' to list ACON TDs/VMs and
+ACON containers running in them.
+
+NOTE: A custom command is an executable file located in /lib/acon/entrypoint.d/
+inside the ACON container's directory tree. Its file name must start with a
+capital letter.
+`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return invoke(args)
 	},
@@ -66,19 +74,19 @@ func init() {
 	rootCmd.AddCommand(invokeCmd)
 
 	invokeCmd.Flags().StringVarP(&vmConnTarget, "connect", "c", "",
-		"connection target for specifying the ACON virtual machine")
+		"protocol/address of the ACON TD/VM")
 	invokeCmd.MarkFlagRequired("connect")
 
 	invokeCmd.Flags().Uint32VarP(&cid, "container", "e", 0,
-		"target ACON container to invoke the command")
+		"the ACON container to execute the custom command")
 	invokeCmd.MarkFlagRequired("container")
 
 	invokeCmd.Flags().Uint64VarP(&timeout, "timeout", "t", 30,
-		"optional timeout in seconds for capturing the command output")
+		"capture up to this number of seconds of the command output")
 
 	invokeCmd.Flags().Uint64VarP(&sizeToCapture, "size", "s", config.DefaultCapSize,
-		"optional size in bytes for capturing the command output")
+		"capture up to this number of bytes of the command output")
 
 	invokeCmd.Flags().StringVarP(&inputfile, "input", "i", "",
-		"optional file to get the input data for the command")
+		"optional file serving as stdin to the command")
 }

--- a/aconcli/cmd/kill.go
+++ b/aconcli/cmd/kill.go
@@ -13,10 +13,22 @@ import (
 )
 
 var killCmd = &cobra.Command{
-	Use:   "kill SIGNAL_NUM",
-	Short: "Send a signal to an ACON container",
+	Use:     "kill signo",
+	Short:   "Signal an ACON container",
+	GroupID: "runtime",
 	Long: `
-Send the specified signal to the ACON container in the VM`,
+Send the specified signal to the ACON container in the specified ACON TD/VM.
+
+The ACON TD/VM must be specified by the '-c' flag while the ACON container must
+be specified by the '-e' flag. Use 'aconcli status' to list ACON TDs/VMs and
+ACON containers running in them.
+
+'signo' (signal number) could be a positive or negative integer. A positive
+signo will be sent to the container process (PID 1) only, while a negative
+signo will cause -signo to be sent to the whole process group led by the
+container process.
+`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return kill(args)
 	},
@@ -47,10 +59,10 @@ func init() {
 	rootCmd.AddCommand(killCmd)
 
 	killCmd.Flags().StringVarP(&vmConnTarget, "connect", "c", "",
-		"connection target for the VM")
+		"protocol/address of the ACON TD/VM")
 	killCmd.MarkFlagRequired("connect")
 
 	killCmd.Flags().Uint32VarP(&cid, "container", "e", 0,
-		"target acon container to invoke the command")
+		"the ACON container to which the signal will be sent")
 	killCmd.MarkFlagRequired("container")
 }

--- a/aconcli/cmd/ls.go
+++ b/aconcli/cmd/ls.go
@@ -20,10 +20,13 @@ import (
 var notrunc bool
 
 var lsCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "List ACON images in the repository",
+	Use:     "ls",
+	Short:   "List ACON images",
+	GroupID: "image",
 	Long: `
-List current ACON image status in the ACON repository`,
+List ACON images in the current acon image repo, whose path is determined by
+the current working directory.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return lsManifest()
 	},

--- a/aconcli/cmd/prune.go
+++ b/aconcli/cmd/prune.go
@@ -12,10 +12,13 @@ import (
 )
 
 var pruneCmd = &cobra.Command{
-	Use:   "prune",
-	Short: "Prune unused file system layers from ACON repository",
+	Use:     "prune",
+	Short:   "Prune unreferenced file system layers",
+	GroupID: "image",
 	Long: `
-Prune unused file system layers from the ACON repository`,
+Prune unused file system layers from the current ACON image repo, whose path is
+determined by the current working directory.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return pruneBlobs()
 	},

--- a/aconcli/cmd/remove.go
+++ b/aconcli/cmd/remove.go
@@ -18,15 +18,20 @@ import (
 var prune bool
 
 var rmCmd = &cobra.Command{
-	Use:   "rm <manifest>...",
-	Short: "Remove one or more manifest from ACON repository",
+	Use:     "rm manifest...",
+	Short:   "Remove ACON images",
+	GroupID: "image",
 	Long: `
-Remove one or more manifest from ACON repository. Manifest can be specified
-either by the file path or by the hash digest which can be obtained by using
-'aconcli ls' subcommand. The certficate file and signature file corresponding
-to the manifest will also be removed while the file system layers will remain
-untouched until 'aconcli prune' subcommand determines they are no longer being
-used and hence removed`,
+Remove one or more ACON images/manifests from their ACON image repos.
+
+Manifests can be specified either by paths or by hash digests, which can be
+obtained by 'aconcli ls'.
+
+'aconcli rm' also removes certficate and signature files associated with the
+specified manifests, but it does NOT remove file system layers as they may be
+shared among multiple ACON images/manifests. 'aconcli prune' can be used to
+clean up unreferenced file system layers.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return removeManifest(args)
 	},

--- a/aconcli/cmd/report.go
+++ b/aconcli/cmd/report.go
@@ -116,13 +116,15 @@ func parseReport(report []byte) error {
 }
 
 var reportCmd = &cobra.Command{
-	Use:   "report <nonce-low>  <nonce-high>",
-	Short: "Get TD report from specified ACON virtual machine",
+	Use:     "report <nonce-low>  <nonce-high>",
+	Short:   "Request TD report or Quote",
+	GroupID: "runtime",
 	Long: `
-Get TD report from an ACON virtual machine. The VM needs to be specified
-using the '-c' flag whose value can be obtained using the 'aconcli status'
-subcommand. 'nonce low' and 'nonce high' represents two 64-bit hexadecimal
-values to be used for attestation`,
+Request a TD report or Quote from an ACON TD/VM.
+
+The ACON TD/VM must be specified by the '-c' flag. Use 'aconcli status' to list
+ACON TDs/VMs and ACON containers running in them.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getReport(args)
 	},

--- a/aconcli/cmd/restart.go
+++ b/aconcli/cmd/restart.go
@@ -12,13 +12,19 @@ import (
 )
 
 var restartCmd = &cobra.Command{
-	Use:   "restart",
-	Short: "Restart specified ACON container",
+	Use:     "restart",
+	Short:   "Restart ACON container",
+	GroupID: "runtime",
 	Long: `
-Restart the specified ACON container within the specified virtual machine.
-The ACON virtual machine needs to be specified by the '-c' flag while ACON
-container needs to be specified by the '-e' flag. Both information can be
-obtained by using the 'aconcli status' subcommand`,
+Restart the specified ACON container in the specified ACON TD/VM.
+
+If the specified ACON container is running, 'aconcli restart' would try to stop
+it before restarting it.
+
+The ACON TD/VM must be specified by the '-c' flag while the ACON container must
+be specified by the '-e' flag. Use 'aconcli status' to list ACON TDs/VMs and
+ACON containers running in them.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return restart(args)
 	},

--- a/aconcli/cmd/root.go
+++ b/aconcli/cmd/root.go
@@ -3,32 +3,24 @@
 
 package cmd
 
-import (
-	"os"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "aconcli",
-	Short: "A command line tool to handle Attested Containers (ACON)",
+	Short: "ACON (Attested Container) Command Line Interface",
 	Long: `
-This tool can be used to handle various aspects of the ACON workloads.
-It can generate a manifest for a workload, sign the manifest, save file
-system layer contents and can also create virtual machines, run workloads
-and check their status`,
+Creates/Manages ACON (Attested Container) images and ACON virtual machines.
+`,
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+func Cli() *cobra.Command {
+	return rootCmd
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&targetDir, "directory", "C", "", "change to directory")
+	rootCmd.AddGroup(
+		&cobra.Group{"image", "ACON Image and Image Repo Commands:"},
+		&cobra.Group{"runtime", "ACON TD/VM and Container Commands:"})
+	rootCmd.PersistentFlags().StringVarP(&targetDir, "directory", "C", "", "change working directory before performing any operations")
 }

--- a/aconcli/cmd/run.go
+++ b/aconcli/cmd/run.go
@@ -30,8 +30,9 @@ var (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run <manifest-file>...",
-	Short: "Start ACON containers",
+	Use:     "run <manifest-file>...",
+	Short:   "Start ACON containers",
+	GroupID: "runtime",
 	Long: `
 Start ACON container(s) in a new (indicated by '-n' flag) or existing
 (indicated by '-c' flag) ACON virtual machine using specified ACON

--- a/aconcli/cmd/shutdown.go
+++ b/aconcli/cmd/shutdown.go
@@ -17,12 +17,19 @@ import (
 var force bool
 
 var shutDownCmd = &cobra.Command{
-	Use:   "shutdown <ACON-vitual-machine>...",
-	Short: "Shut down ACON virtual machines and related containers",
+	Use:     "shutdown <ACON-vitual-machine>...",
+	Short:   "Shut down ACON TD/VM",
+	GroupID: "runtime",
 	Long: `
-Shut down ACON virtual machines and related containers. The virtual machines
-need to be specified by the '-c' flag and can be obtained by using the
-'aconcli status' subcommand`,
+Shut down the specified ACON TD/VM.
+
+When there are running containers, 'aconcli shutdown' would try to stop them as
+if 'aconcli stop' were invoked on each of them, before shutting down the ACON
+TD/VM.
+
+The ACON TD/VM must be specified by the '-c' flag. Use 'aconcli status' to list
+ACON TDs/VMs and ACON containers running in them.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return removeVM(args)
 	},

--- a/aconcli/cmd/sign.go
+++ b/aconcli/cmd/sign.go
@@ -15,11 +15,23 @@ import (
 var resign bool = false
 
 var signCmd = &cobra.Command{
-	Use:   "sign <manifest-file>",
-	Short: "Sign the manifest file",
+	Use:     "sign manifest",
+	Short:   "Sign an ACON image",
+	GroupID: "image",
 	Long: `
-Sign the manifest file using the specified private key file and hash
-algorithm extracted from the specified certificate file`,
+Sign the specified ACON image/manifest and store the signature in the ACON
+image repo.
+
+When signing a manifest for the first time, both a private key file and its
+corresponding certificate file must be specified. The certificate file is used
+to determine the hash algorithm when creating the digital signature. 'aconcli
+sign' keeps symlinks (in the ACON image repo) to the private key and
+certificate files to facilitate future re-signing.
+
+When re-signing a manifest, 'aconcli sign' reuses the private key and
+certifcate files by default, and can be overridden by respective command line
+flags.
+`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return signManifest(args)

--- a/aconcli/cmd/status.go
+++ b/aconcli/cmd/status.go
@@ -18,10 +18,13 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show status of ACON virtual machines and related containers",
+	Use:     "status",
+	Short:   "Show status of ACON TDs/VMs and containers",
+	GroupID: "runtime",
 	Long: `
-Show status of all the ACON virtual machines and their related containers`,
+Show status of all ACON TDs/VMs running in the local platform and containers running in them.
+`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return showStatus()
 	},

--- a/aconcli/cmd/stop.go
+++ b/aconcli/cmd/stop.go
@@ -12,13 +12,16 @@ import (
 )
 
 var stopCmd = &cobra.Command{
-	Use:   "stop <ACON-virtual-machine> <ACON-containers>...",
-	Short: "Stop ACON containers within an ACON virtual machine",
+	Use:     "stop <ACON-virtual-machine> <ACON-containers>...",
+	Short:   "Stop ACON containers",
+	GroupID: "runtime",
 	Long: `
-Stop ACON containers in an ACON virtual machine. VM can be specified by
-the connection target and containers are specified by the container id.
-VM and container information can be obtained by using the 'aconcli status'
-subcommand`,
+Stop ACON containers in an ACON TD/VM.
+
+The ACON TD/VM must be specified by the '-c' flag while the ACON container must
+be specified by the '-e' flag. Use 'aconcli status' to list ACON TDs/VMs and
+ACON containers running in them.
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return stopAcons(args)
 	},

--- a/aconcli/main.go
+++ b/aconcli/main.go
@@ -3,8 +3,13 @@
 
 package main
 
-import "aconcli/cmd"
+import (
+	"aconcli/cmd"
+	"os"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Cli().Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
aconcli commands are now divided into 3 groups:

- Image commands are those operating on ACON images and ACON image repos.
- Runtime commands are for creating/managing TDs/VMs and containers.
- Additional commands include `help`, `completion` and `hash`.

Most commands now have more detailed help messages.

This commit also changes the output of `hash` to align with SignerID and ImageID as defined in the ACON image spec.