### PR TITLE
scripts/acon-build.env: Request tty only if stdin is tty

### DIFF
--- a/scripts/acon-build.env
+++ b/scripts/acon-build.env
@@ -817,7 +817,7 @@ starts.
     done
 
     if test $# -gt 0; then
-        local RM="--rm --init"
+        local _RM="--rm --init"
     else
         set -- sh -i
     fi
@@ -840,9 +840,11 @@ starts.
     }
 
     local readonly rustimg=rust:${RUSTAG:-alpine}
-    test -z "$RM" &&
+    test -z "$_RM" &&
     printf "${_FB}%s${_FP}\\t%s\\n" 'ACON Repo' "$ACON" 'Rust OCI Image' $rustimg |
     column -t -s$'\t' >&2
+
+    test -t 0 && local readonly _TTY=-t
 
     local readonly chash=$(sha1sum <<< "$ACON\\$rustimg\\$HTTPS_PROXY\\$https_proxy")
     local readonly cname=acon-rust.$(id -un).${chash:0:12}
@@ -851,14 +853,14 @@ starts.
             echo -e ${_inf}$cname: Starting existing container... >&2
             docker start -ia $cname;;
         xrunning)
-            test -z "$RM" && echo -e ${_wrn}$cname: Executing new shell in running container... >&2
-            docker exec -it $cname "$@";;
+            test -z "$_RM" && echo -e ${_wrn}$cname: Executing new shell in running container... >&2
+            docker exec -i $_TTY $cname "$@";;
         xpaused)
             echo -e ${_wrn}$cname: Resuming paused container in its original terminal... >&2
             docker unpause $cname;;
         x)
             echo -e ${_inf}$cname: Creating new container... >&2
-            docker run $RM -it --name $cname --label ACON=$ACON -v $ACON:/acon -w /acon/acond \
+            docker run $_RM -i $_TTY --name $cname --label ACON=$ACON -v $ACON:/acon -w /acon/acond \
                 -e HTTPS_PROXY -e https_proxy ${U:+-e U=${U/#.*/$(id -u):$(id -g)}} $rustimg sh -c "
                 . /etc/os-release || {
                     echo -e \"${_err}/etc/os-release: Not found\" >&2

--- a/scripts/acon-build.env
+++ b/scripts/acon-build.env
@@ -883,6 +883,7 @@ starts.
                     if test \"\${U%:*}\" -gt 0 2> /dev/null; then
                         grep -l ^u\${U%:*}:x /etc/passwd ||
                         echo u\${U%:*}:x:\$U:xuser:/:/sbin/nologin >> /etc/passwd
+                        chown -R \$U ../scripts/deps
 
                         apk --cache-dir /var/cache/apk add daemontools-encore &&
                         exec setuidgid u\${U%:*} \"\$@\"


### PR DESCRIPTION
This commit addresses #28 by testing if stdin is tty before appending `-t` option to docker command line.