### PR TITLE
aconcli: Fix issue #30

### DIFF
--- a/aconcli/repo/repo.go
+++ b/aconcli/repo/repo.go
@@ -726,7 +726,7 @@ func createSymlink(oldname, newname string) error {
 
 	// remove obsolete symlink
 	if finfo, err := os.Lstat(newname); err == nil {
-		if finfo.Mode() == fs.ModeSymlink {
+		if finfo.Mode()&fs.ModeSymlink == fs.ModeSymlink {
 			os.Remove(newname)
 		}
 	}

--- a/aconcli/service/service.go
+++ b/aconcli/service/service.go
@@ -147,12 +147,12 @@ func Inspect(sc pb.AconServiceClient, cid uint32) ([]AconStatus, error) {
 	return result, nil
 }
 
-func Report(sc pb.AconServiceClient, nonceLo, nonceHi uint64) (data []byte,
+func Report(sc pb.AconServiceClient, nonceLo, nonceHi uint64, requestType uint32) (data []byte,
 	mrlog0 []string, mrlog1 []string, mrlog2 []string, mrlog3 []string, attest_data string, e error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultServiceTimeout)
 	defer cancel()
 
-	r, err := sc.Report(ctx, &pb.ReportRequest{NonceLo: nonceLo, NonceHi: nonceHi})
+	r, err := sc.Report(ctx, &pb.ReportRequest{NonceLo: nonceLo, NonceHi: nonceHi, RequestType: requestType})
 	if err != nil {
 		e = err
 		return


### PR DESCRIPTION
1. `generate` errs on existing FS layer symlinks
2. `generate` now takes output file name as a parameter and docker image/tag by a flag
3. `report` missing flag/option to request a quote instead of a report
4. `report` should generate nonce at random if not specified by the use
5. `sign` errs on re-signing