### PR TITLE
aconcli: Fix aconcli to append to (instead of setting) ATD_TCPFWD env var

### DIFF
--- a/aconcli/.gitignore
+++ b/aconcli/.gitignore
@@ -1,0 +1,3 @@
+aconcli
+proto/acon_grpc.pb.go
+proto/acon.pb.go

--- a/aconcli/cmd/status.go
+++ b/aconcli/cmd/status.go
@@ -14,6 +14,7 @@ import (
 	"aconcli/repo"
 	"aconcli/service"
 	"aconcli/vm"
+
 	"github.com/spf13/cobra"
 )
 
@@ -105,7 +106,7 @@ func convertImageId(bundleId string) string {
 }
 
 func showStatus() error {
-	vmPids, conns, err := vm.GetAllVM(config.AconVmName)
+	vmPids, conns, err := vm.GetAllVM(config.AconVmPrefix)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Show Status: cannot fetch VM information: %v\n", err)
 		return err

--- a/aconcli/config/config.go
+++ b/aconcli/config/config.go
@@ -18,5 +18,6 @@ const (
 	EntrypointName     = "/lib/acon/entrypoint.d/start"
 	ShortHashLen       = 12
 	DefaultCapSize     = 0x20000
-	AconVmName         = "aconvm"
+	AconVmPrefix       = "aconvm-"
+	AconVmEnvTag       = "__ACONVM="
 )

--- a/aconcli/vm/vm.go
+++ b/aconcli/vm/vm.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"aconcli/config"
+
 	"github.com/prometheus/procfs"
 )
 
@@ -105,7 +106,7 @@ func GetAllVM(vmNamePrefix string) ([]string, []string, error) {
 }
 
 func GetPid(connTarget string) (int, error) {
-	vmPids, conns, err := GetAllVM(config.AconVmName)
+	vmPids, conns, err := GetAllVM(config.AconVmPrefix)
 	if err != nil {
 		return -1, fmt.Errorf("get pid for (%s): %v", connTarget, err)
 	}
@@ -149,7 +150,7 @@ func getConnTarget(pid string) (string, error) {
 
 	var connTarget string
 	for _, ev := range environ {
-		if strings.HasPrefix(ev, "ACON_STARTVM_PARAM_CONN_TARGET") {
+		if strings.HasPrefix(ev, config.AconVmEnvTag) {
 			connTarget = ev
 			break
 		}

--- a/scripts/acon-startvm
+++ b/scripts/acon-startvm
@@ -4,7 +4,7 @@
 
 dump_env() {
     while test $# -gt 0; do
-        eval "local readonly _V=\${$1:-(not\ set)}"
+        eval "local readonly _V=\"\${$1:-(not set)}\""
         printf '%s\t= %s\t# %s\n' $1 "$_V" "$2"
         shift 2
     done |


### PR DESCRIPTION
This commit changes `aconcli` to append to (instead of setting) `ATD_TCPFWD`, so that forwarding rules set by the user will not be overwritten.