### PR TITLE
script: Label rust container with proxy setting

### DIFF
--- a/scripts/acon-build.env
+++ b/scripts/acon-build.env
@@ -825,22 +825,42 @@ starts.
         set -- sh -i
     fi
 
-    test -n "$ACON" || local ACON=$(git rev-parse --show-toplevel)
+    test -n "$ACON" || local ACON="$(git rev-parse --show-toplevel)"
     test -n "$ACON" || {
         echo -e ${_err}Failed to deduce ACON root from current directory >&2
         return 3
     }
 
-    test -e "$ACON/scripts/${BASH_SOURCE[0]##*/}" || {
+    test -e "$ACON/scripts/${BASH_SOURCE[0]##*/}" -a -d "$ACON/acond" || {
         echo -e ${_err}$ACON: Not an ACON source tree >&2
         return 4
     }
 
-    ACON=$(readlink -f $ACON)
-    test -d "$ACON" -a -z "${ACON##/*}" || {
-        echo -e ${_err}$ACON isn\'t a valid directory path >&2
-        return 4
+    ACON=$(realpath -es "$ACON")
+    test -z "$ACON" && {
+        echo -e ${_err}${BASH_SOURCE[0]}#$LINENO: Internal error >&2
+        return $LINENO
     }
+
+    case x$U in
+        x)  ;;
+        x.)
+            H=~/.cargo.rust-container
+            U=:
+            ;&
+        x*:*)
+            U=$(id -u ${U%:*}):$(id -g ${U##*:})
+            ;;
+        x*)
+            U=$(id -u $U):$(id -u $U)
+            ;;
+    esac
+    test -n "$U" && ! test ${U%:*} -ge 0 -a ${U##*:} -ge 0 && {
+        echo -e ${_err}U must be set to one of '.', ':', or USER:GROUP >&2
+        return 5
+    }
+
+    test -n "$H" && H="$(realpath -ms "$H")" && mkdir -p "$H"
 
     local readonly rustimg=rust:${RUSTAG:-alpine}
     test -z "$_RM" &&
@@ -864,9 +884,12 @@ starts.
         x)
             echo -e ${_inf}$cname: Creating new container... >&2
             docker run $_RM -i $_TTY --name $cname \
-                ${https_proxy:+--label https_proxy=$https_proxy} --label ACON=$ACON \
-                -v $ACON:/acon -w /acon/acond -e https_proxy \
-                ${U:+-e U=${U/#.*/$(id -u):$(id -g)}} $rustimg sh -c "
+                ${https_proxy:+-e https_proxy --label https_proxy=$https_proxy} \
+                ${U:+-e U --label U=$U} \
+                ${H:+-v "$H:/cargo" -e CARGO_HOME=/cargo --label "CARGO_HOME=$H"} \
+                -v "$ACON:/acon" --label "ACON=$ACON" -w /acon/acond \
+                --tmpfs /tmp:size=1g \
+                $rustimg sh -c "
                 . /etc/os-release || {
                     echo -e \"${_err}/etc/os-release: Not found\" >&2
                     exit 1

--- a/scripts/acon-build.env
+++ b/scripts/acon-build.env
@@ -849,7 +849,7 @@ starts.
 
     test -t 0 && local readonly _TTY=-t
 
-    local readonly chash=$(sha1sum <<< "$ACON\\$rustimg\\$HTTPS_PROXY\\$https_proxy")
+    local readonly chash=$(sha1sum <<< "$ACON\\$rustimg\\${https_proxy:=$HTTPS_PROXY}")
     local readonly cname=acon-rust.$(id -un).${chash:0:12}
     case x$(docker ps -af name=$cname --format "{{.State}}") in
         xcreated|xexited)
@@ -863,8 +863,10 @@ starts.
             docker unpause $cname;;
         x)
             echo -e ${_inf}$cname: Creating new container... >&2
-            docker run $_RM -i $_TTY --name $cname --label ACON=$ACON -v $ACON:/acon -w /acon/acond \
-                -e HTTPS_PROXY -e https_proxy ${U:+-e U=${U/#.*/$(id -u):$(id -g)}} $rustimg sh -c "
+            docker run $_RM -i $_TTY --name $cname \
+                ${https_proxy:+--label https_proxy=$https_proxy} --label ACON=$ACON \
+                -v $ACON:/acon -w /acon/acond -e https_proxy \
+                ${U:+-e U=${U/#.*/$(id -u):$(id -g)}} $rustimg sh -c "
                 . /etc/os-release || {
                     echo -e \"${_err}/etc/os-release: Not found\" >&2
                     exit 1


### PR DESCRIPTION
This small change in `acon-build.env` labels rust container with proxy setting so that user can easily tell which container was started with which HTTPS proxy. This change is useful for laptops whose proxy settings may change when the user is travelling.