### PR TITLE
Improve OpenSSF securitycard score

### DIFF
--- a/.github/workflows/cicd-busybox.yml
+++ b/.github/workflows/cicd-busybox.yml
@@ -13,13 +13,20 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   CICD:
 
     runs-on: self-hosted
     name: CICD-BusyBox
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
     - name: Enable busybox docker
       run: |
         source scripts/start-happypath.sh


### PR DESCRIPTION
`https://securityscorecards.dev/viewer/?uri=github.com%2Fintel%2FACON`

The initial security score of ACON is 5.3. OpenSSF aims for a project score of 7.5, so we are working to improve ACON's Scorecard results

There are 2 high security level items with low score, and increase score from 0 to 10:
- Dangerous Workflow (0) -> Dangerous Workflow (10)
- Pinned-Dependencies(0) -> Pinned-Dependencies(10)