### PR TITLE
acond: fix issue 76 - Encounter apr_sockaddr_info_get() failed for vm…

### DIFF
--- a/acond/src/container.rs
+++ b/acond/src/container.rs
@@ -478,6 +478,14 @@ fn run_child(fork_args: &ForkArgs, slave: Option<i32>, csock: i32) -> Result<Pid
             fs::create_dir_all(&path)?;
             unistd::chown(&path, Some(Uid::from_raw(*key)), Some(Gid::from_raw(*key)))?;
         }
+
+        #[cfg(not(feature = "interactive"))]
+        {
+            let null_fd = fcntl::open("/dev/null", OFlag::O_WRONLY, Mode::empty())?;
+            unistd::dup2(null_fd, libc::STDOUT_FILENO)?;
+            unistd::dup2(null_fd, libc::STDERR_FILENO)?;
+            unistd::close(null_fd)?;
+        }
     }
 
     unistd::chroot(&rootfs)?;

--- a/acond/src/mount.rs
+++ b/acond/src/mount.rs
@@ -154,7 +154,7 @@ fn mount_fstab() -> Result<()> {
                 fields[1],
                 e
             );
-            return Err(e.into());
+            return Err(e);
         }
     }
 


### PR DESCRIPTION
As discussed, redirect stdout/stderr to /dev/null when PTY is NOT supported.